### PR TITLE
feat: add `ledger-is-iframe-ready` action handler

### DIFF
--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -26,6 +26,13 @@ export default class LedgerBridge {
           const replyAction = `${action}-reply`;
 
           switch (action) {
+            case 'ledger-is-iframe-ready':
+              this.sendMessageToExtension({
+                action: replyAction,
+                success: true,
+                messageId,
+              });
+              break;
             case 'ledger-unlock':
               this.unlock(replyAction, params.hdPath, messageId);
               break;


### PR DESCRIPTION
This PR adds an additional message handler on the bridge to be used by the parent window to ensure the iframe is up and running, and ready to handle messages.

Related to https://github.com/MetaMask/accounts/issues/258