### PR TITLE
ci: update pages deployment to use deploy token

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -8,11 +8,6 @@ on:
         required: true
         type: string
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
-permissions:
-  contents: write
-  pages: write
-  id-token: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -21,23 +16,17 @@ concurrency:
   cancel-in-progress: false
 
 jobs:
-  # Deployment job
   deploy:
     runs-on: ubuntu-latest
+    environment: github-pages
     steps:
       - name: Ensure destination folder is not empty
         if: ${{ inputs.destination_dir == '' }}
         run: exit 1
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Enable Corepack
-        run: corepack enable
-      - name: Setup Node.js environment
-        uses: actions/setup-node@v4.1.0
+      - name: Checkout and setup environment
+        uses: MetaMask/action-checkout-and-setup@v1
         with:
-          cache: yarn
-      - name: Install dependencies
-        run: yarn install
+          is-high-risk-environment: true
       - name: Build static files
         env:
           VITE_VERSION: ${{ inputs.destination_dir }}
@@ -45,6 +34,6 @@ jobs:
       - name: Deploy to `${{ inputs.destination_dir }}` directory of `gh-pages` branch
         uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          personal_token: ${{ secrets.GH_PAGES_DEPLOY_TOKEN }}
           publish_dir: ./dist
           destination_dir: ${{ inputs.destination_dir }}


### PR DESCRIPTION
## Summary

 This pull request scopes GitHub pages deployments to the `github-pages` environment which introduces a token that can be used to perform these deployments. This comes with added security benefits that have been rolled out to other GitHub pages repositories. 