### PR TITLE
fix: `attemptMakeApp` action returns error in payload

### DIFF
--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -133,7 +133,7 @@ export default class LedgerBridge {
         action: replyAction,
         success: false,
         messageId,
-        error,
+        payload: { error },
       });
     }
   }


### PR DESCRIPTION
After [this change](https://github.com/MetaMask/metamask-extension/commit/7b8d936cee071021730bc5849d1109b89d3667b5) on extension, all actions are expected to return an eventual `error` in the `payload` response property. 

This is mostly true, with the exception of `attemptMakeApp` that has a first level `error` property in the response object. We can move `error` into `payload` to align it with other action responses

Related to https://github.com/MetaMask/metamask-extension/issues/33177