### PR TITLE
fix: Ledger error serialization issue in metamask extension.

### DIFF
--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -19,8 +19,8 @@ const serializeError = (error) => {
       name: error.name,
       stack: error.stack,
       text: error.text || undefined,
-      statusCode: error.statusCode || undefined,
-      statusText: error.statusText || undefined,
+      statusCode: error.statusCode,
+      statusText: error.statusText,
     };
   }
 

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -3,6 +3,7 @@ import TransportWebHID from '@ledgerhq/hw-transport-webhid';
 import LedgerEth from '@ledgerhq/hw-app-eth';
 import WebSocketTransport from '@ledgerhq/hw-transport-http/lib/WebSocketTransport';
 import { SignTypedDataVersion, TypedDataUtils } from '@metamask/eth-sig-util';
+import { TransportStatusError } from '@ledgerhq/errors';
 
 // URL which triggers Ledger Live app to open and handle communication
 const BRIDGE_URL = 'ws://localhost:8435';
@@ -10,6 +11,25 @@ const BRIDGE_URL = 'ws://localhost:8435';
 // Number of seconds to poll for Ledger Live and Ethereum app opening
 const TRANSPORT_CHECK_DELAY = 1000;
 const TRANSPORT_CHECK_LIMIT = 120;
+
+const serializeError = (error) => {
+  if (error instanceof TransportStatusError) {
+    return {
+      message: error.message,
+      name: error.name,
+      stack: error.stack,
+      text: error.text || undefined,
+      statusCode: error.statusCode || undefined,
+      statusText: error.statusText || undefined,
+    };
+  }
+
+  return {
+    message: error.message,
+    name: error.name,
+    stack: error.stack,
+  };
+};
 
 export default class LedgerBridge {
   constructor() {
@@ -133,7 +153,7 @@ export default class LedgerBridge {
         action: replyAction,
         success: false,
         messageId,
-        payload: { error },
+        payload: { error: serializeError(error) },
       });
     }
   }
@@ -209,12 +229,11 @@ export default class LedgerBridge {
         payload: res,
         messageId,
       });
-    } catch (err) {
-      const e = this.ledgerErrToMessage(err);
+    } catch (error) {
       this.sendMessageToExtension({
         action: replyAction,
         success: false,
-        payload: { error: e },
+        payload: { error: serializeError(error) },
         messageId,
       });
     } finally {
@@ -238,12 +257,11 @@ export default class LedgerBridge {
         payload: res,
         messageId,
       });
-    } catch (err) {
-      const e = this.ledgerErrToMessage(err);
+    } catch (error) {
       this.sendMessageToExtension({
         action: replyAction,
         success: false,
-        payload: { error: e },
+        payload: { error: serializeError(error) },
         messageId,
       });
     } finally {
@@ -264,12 +282,11 @@ export default class LedgerBridge {
         payload: res,
         messageId,
       });
-    } catch (err) {
-      const e = this.ledgerErrToMessage(err);
+    } catch (error) {
       this.sendMessageToExtension({
         action: replyAction,
         success: false,
-        payload: { error: e },
+        payload: { error: serializeError(error) },
         messageId,
       });
     } finally {
@@ -292,12 +309,11 @@ export default class LedgerBridge {
         payload: res,
         messageId,
       });
-    } catch (err) {
-      const e = this.ledgerErrToMessage(err);
+    } catch (error) {
       this.sendMessageToExtension({
         action: replyAction,
         success: false,
-        payload: { error: e },
+        payload: { error: serializeError(error) },
         messageId,
       });
     } finally {

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -18,7 +18,7 @@ const serializeError = (error) => {
       message: error.message,
       name: error.name,
       stack: error.stack,
-      text: error.text || undefined,
+      text: error.text,
       statusCode: error.statusCode,
       statusText: error.statusText,
     };

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -18,7 +18,6 @@ const serializeError = (error) => {
       message: error.message,
       name: error.name,
       stack: error.stack,
-      text: error.text,
       statusCode: error.statusCode,
       statusText: error.statusText,
     };


### PR DESCRIPTION
This PR will fix the metamask extension issue https://github.com/MetaMask/metamask-extension/issues/29802

The problem was caused that javascript Error's properties were immutable properties, during postMessage to metamask extension. that Error object will be serialised as empty object (all immutable properties will be escaped.)

this PR will create a SerializedError method to copy the immutable properties values into a new javascript object. and then post ot metamask extension. in metamask-extension, we will have special code to convert it back to TransportStatusError or normal error type.