### PR TITLE
feat: add getAppNameAndVersion

### DIFF
--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -237,6 +237,10 @@ export default class LedgerBridge {
         payload: { error: serializeError(error) },
         messageId,
       });
+    } finally {
+      if (this.transportType !== 'ledgerLive') {
+        this.cleanUp();
+      }
     }
   }
 

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -210,14 +210,14 @@ export default class LedgerBridge {
 
       const appName = response
         .slice(i, (i += nameLength))
-        .toString(this.transportEncoding);
+        .toString();
 
       const versionLength = response[i] ?? 0;
       i += 1;
 
       const version = response
         .slice(i, (i += versionLength))
-        .toString(this.transportEncoding);
+        .toString();
 
       const res = {
         appName,

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -33,7 +33,7 @@ const serializeError = (error) => {
 export default class LedgerBridge {
   constructor() {
     this.addEventListeners();
-    this.transportType = 'webhid';
+    this.transportType = 'u2f';
   }
 
   addEventListeners() {

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -33,7 +33,7 @@ const serializeError = (error) => {
 export default class LedgerBridge {
   constructor() {
     this.addEventListeners();
-    this.transportType = 'u2f';
+    this.transportType = 'webhid';
   }
 
   addEventListeners() {
@@ -101,6 +101,9 @@ export default class LedgerBridge {
               break;
             case 'ledger-make-app':
               this.attemptMakeApp(replyAction, messageId);
+              break;
+            case 'ledger-get-app-name-and-version':
+              this.getAppAndName(replyAction, messageId);
               break;
             case 'ledger-sign-typed-data':
               this.signTypedData(
@@ -193,9 +196,53 @@ export default class LedgerBridge {
     }
   }
 
-  updateTransportTypePreference(replyAction, transportType, messageId) {
+  async getAppAndName(replyAction, messageId) {
+    try {
+      await this.makeApp();
+      const response = await this.transport.send(0xb0, 0x01, 0x00, 0x00);
+      if (response[0] !== 1) {
+        throw new Error('Incorrect format return from getAppNameAndVersion.');
+      }
+
+      let i = 1;
+      const nameLength = response[i] ?? 0;
+      i += 1;
+
+      const appName = response
+        .slice(i, (i += nameLength))
+        .toString(this.transportEncoding);
+
+      const versionLength = response[i] ?? 0;
+      i += 1;
+
+      const version = response
+        .slice(i, (i += versionLength))
+        .toString(this.transportEncoding);
+
+      const res = {
+        appName,
+        version,
+      };
+
+      this.sendMessageToExtension({
+        action: replyAction,
+        success: true,
+        payload: res,
+        messageId,
+      });
+    } catch (error) {
+      this.sendMessageToExtension({
+        action: replyAction,
+        success: false,
+        payload: { error: serializeError(error) },
+        messageId,
+      });
+    }
+  }
+
+  async updateTransportTypePreference(replyAction, transportType, messageId) {
     this.transportType = transportType;
-    this.cleanUp();
+    await this.cleanUp();
     this.sendMessageToExtension({
       action: replyAction,
       success: true,

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -240,9 +240,9 @@ export default class LedgerBridge {
     }
   }
 
-  async updateTransportTypePreference(replyAction, transportType, messageId) {
+  updateTransportTypePreference(replyAction, transportType, messageId) {
     this.transportType = transportType;
-    await this.cleanUp();
+    this.cleanUp();
     this.sendMessageToExtension({
       action: replyAction,
       success: true,

--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -103,7 +103,7 @@ export default class LedgerBridge {
               this.attemptMakeApp(replyAction, messageId);
               break;
             case 'ledger-get-app-name-and-version':
-              this.getAppAndName(replyAction, messageId);
+              this.getAppNameAndVersion(replyAction, messageId);
               break;
             case 'ledger-sign-typed-data':
               this.signTypedData(
@@ -196,9 +196,10 @@ export default class LedgerBridge {
     }
   }
 
-  async getAppAndName(replyAction, messageId) {
+  async getAppNameAndVersion(replyAction, messageId) {
     try {
       await this.makeApp();
+      // See: https://github.com/LedgerHQ/ledger-live/blob/v22.0.1/src/hw/getAppAndVersion.ts  
       const response = await this.transport.send(0xb0, 0x01, 0x00, 0x00);
       if (response[0] !== 1) {
         throw new Error('Incorrect format return from getAppNameAndVersion.');


### PR DESCRIPTION
This PR adds a new method, getAppNameAndVersion, for the ledger bridge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a minimal API to retrieve the active Ledger app info through the bridge.
> 
> - Handles new `ledger-get-app-name-and-version` action in `ledger-bridge.js`
> - Implements `getAppAndName()` to open transport, send APDU `0xb0 0x01`, parse `appName` and `version`, and reply with success/error
> - Performs transport cleanup after request (except when using `ledgerLive`)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 099211e7cae12bbd716fc39115eb74c025894e28. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->