### PR TITLE
fix: default to webhid

### DIFF
--- a/ledger-bridge.js
+++ b/ledger-bridge.js
@@ -33,7 +33,7 @@ const serializeError = (error) => {
 export default class LedgerBridge {
   constructor() {
     this.addEventListeners();
-    this.transportType = 'u2f';
+    this.transportType = 'webhid';
   }
 
   addEventListeners() {


### PR DESCRIPTION
This PR updates the default transport to webhid because u2f has been deprecated on chrome and firefox

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prioritizes modern browser support by changing the default Ledger transport.
> 
> - Sets `transportType` to `webhid` (was `u2f`) in `ledger-bridge.js` constructor, making WebHID the default connection method
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4b34c89653bb0a6fd367c155211780865010be6c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->